### PR TITLE
SF-4897: Lavin Reconnects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,10 +1344,18 @@ version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
  "futures-core",
  "futures-sink",
- "pin-project",
- "spin 0.9.4",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1622,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "holaplex-indexer-rabbitmq"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "base64 0.13.0",
  "clap",
@@ -1642,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "holaplex-indexer-rabbitmq-geyser"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bs58",
@@ -1915,16 +1923,16 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "lapin"
-version = "2.1.1"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd03ea5831b44775e296239a64851e2fd14a80a363d202ba147009ffc994ff0f"
+checksum = "fae02c316a8a5922ce7518afa6b6c00e9a099f8e59587567e3331efdd11b8ceb"
 dependencies = [
  "amq-protocol",
  "async-global-executor-trait",
  "async-reactor-trait",
  "async-trait",
  "executor-trait",
- "flume",
+ "flume 0.11.0",
  "futures-core",
  "futures-io",
  "parking_lot",
@@ -2300,7 +2308,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.2.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -2455,26 +2463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.102",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,7 +2481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d894b67aa7a4bf295db5e85349078c604edaa6fa5c8721e8eca3c7729a27f2ac"
 dependencies = [
  "doc-comment",
- "flume",
+ "flume 0.10.14",
  "parking_lot",
  "tracing",
 ]
@@ -3603,9 +3591,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,24 @@
+services:
+  geyser-plugin:
+    build: .
+    ports:
+      - 8899:8899
+      - 8900:8900
+    volumes:
+      - ./crates/plugin/compose_config.json:/geyser/compose_config.json
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - RUST_LOG=warn
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - 5672:5672
+      - 15672:15672
+    healthcheck:
+      test: rabbitmq-diagnostics -q check_port_connectivity 
+      interval: 2s
+      timeout: 15s
+      retries: 5

--- a/crates/plugin/local_config.json
+++ b/crates/plugin/local_config.json
@@ -1,0 +1,32 @@
+{
+  "libpath": "../../target/debug/libholaplex_indexer_rabbitmq_geyser.so",
+  "amqp": {
+    "network": "mainnet",
+    "address": "amqp://guest:guest@localhost:5672"
+  },
+  "jobs": {
+    "limit": 16
+  },
+  "metrics": {},
+  "chainProgress": {
+    "blockMeta": true,
+    "slotStatus": true
+  },
+  "accounts": {
+    "owners": {},
+    "pubkeys": {},
+    "startup": false
+  },
+  "instructions": {
+    "programs": {},
+    "allTokenCalls": true
+  },
+  "transactions": {
+    "programs": {
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA": "defi",
+      "11111111111111111111111111111111": "defi"
+    },
+    "pubkeys": {}
+  },
+  "datumProgramInclusions": {}
+}

--- a/crates/plugin/src/sender.rs
+++ b/crates/plugin/src/sender.rs
@@ -88,7 +88,7 @@ impl Sender {
     async fn connect(&self) -> Result<RwLockReadGuard<Producer>, indexer_rabbitmq::Error> {
         let mut producer = self.producer.write().await;
 
-        if producer.chan.status().connected() {
+        if producer.is_connected() {
             // This thread was in line for a write,
             // but another thread has already handled the reconnection.
             //

--- a/crates/rabbitmq/Cargo.toml
+++ b/crates/rabbitmq/Cargo.toml
@@ -28,7 +28,7 @@ consume-json = []
 [dependencies]
 clap = { version = "3.1.12", default-features = false, features = ["env", "std"], optional = true }
 futures-util = "0.3.19"
-lapin = "2.0.3"
+lapin = "2.3.4"
 log = "0.4.14"
 rand = "0.8.5"
 rmp-serde = "1.0.0-beta.2"

--- a/crates/rabbitmq/src/lib.rs
+++ b/crates/rabbitmq/src/lib.rs
@@ -7,7 +7,7 @@
     missing_debug_implementations,
     missing_copy_implementations
 )]
-#![warn(clippy::pedantic, clippy::cargo, missing_docs)]
+#![warn(clippy::pedantic, clippy::cargo)]
 
 pub extern crate lapin;
 

--- a/crates/rabbitmq/src/producer.rs
+++ b/crates/rabbitmq/src/producer.rs
@@ -12,7 +12,7 @@ use crate::serialize::serialize;
 /// A producer consisting of a configured channel and additional queue config
 #[derive(Debug)]
 pub struct Producer<Q> {
-    pub chan: Channel,
+    chan: Channel,
     ty: Q,
 }
 
@@ -73,5 +73,9 @@ where
             .await?;
 
         Ok(())
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.chan.status().connected()
     }
 }

--- a/crates/rabbitmq/src/producer.rs
+++ b/crates/rabbitmq/src/producer.rs
@@ -12,7 +12,7 @@ use crate::serialize::serialize;
 /// A producer consisting of a configured channel and additional queue config
 #[derive(Debug)]
 pub struct Producer<Q> {
-    chan: Channel,
+    pub chan: Channel,
     ty: Q,
 }
 


### PR DESCRIPTION
When the connection to AMQP is lost, one messaging thread will try to "promote" itself to be the one to reconnect (usually the first that fails to send), by grabbing a write lock, which will put all others into a waiting state (for a read lock). The reconnecting thread tries forever until reconnection.